### PR TITLE
Envjsrb

### DIFF
--- a/src/html/textarea.js
+++ b/src/html/textarea.js
@@ -17,6 +17,9 @@ __extend__(HTMLTextAreaElement.prototype, {
     get rows(){
         return this.getAttribute('rows');
     },
+    get value(){
+        return this.innerText;
+    },
     set rows(value){
         this.setAttribute('rows', value);
     }

--- a/test/unit/elementmembers.js
+++ b/test/unit/elementmembers.js
@@ -7,7 +7,7 @@ test("textarea content", function() {
   var textarea = document.createElement('textarea');
   var text     = document.createTextNode('text-area-content');
   textarea.appendChild(text);
-alert(textarea.value);
+
   try { ok(textarea.value == 'text-area-content',
         "textarea.value returns the correct content, as per http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-24874179");
   }catch(e){print(e);}

--- a/test/unit/elementmembers.js
+++ b/test/unit/elementmembers.js
@@ -3,6 +3,20 @@ module("elementmembers");
 // We ought to have test coverage for all members of all DOM objects, but
 // until then, add test cases here for members as they are created
 
+test("textarea content", function() {
+  var textarea = document.createElement('textarea');
+  var text     = document.createTextNode('text-area-content');
+  textarea.appendChild(text);
+alert(textarea.value);
+  try { ok(textarea.value == 'text-area-content',
+        "textarea.value returns the correct content, as per http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-24874179");
+  }catch(e){print(e);}
+  
+  try { ok(textarea.innerText == 'text-area-content',
+        "textarea.innerText returns the correct content");
+  }catch(e){print(e);}
+});
+
 test("attributes common to all HTML elements", function() {
     expect(4);
 

--- a/test/unit/elementmembers.js
+++ b/test/unit/elementmembers.js
@@ -4,6 +4,8 @@ module("elementmembers");
 // until then, add test cases here for members as they are created
 
 test("textarea content", function() {
+  expect(2);
+  
   var textarea = document.createElement('textarea');
   var text     = document.createTextNode('text-area-content');
   textarea.appendChild(text);


### PR DESCRIPTION
The value property of a textarea should return the content of that textarea (as per http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-24874179).  You can currently get the content of the textarea from the innerText property but that's no good for jquery.  The jquery val(), and in turn serialize(), function expects to be able to use the value property, as per the DOM specification.

These commits add tests and a textarea specific value property that's currently just an alias for innerText.
