### PR TITLE
Envjsrb

### DIFF
--- a/src/html/textarea.js
+++ b/src/html/textarea.js
@@ -20,6 +20,9 @@ __extend__(HTMLTextAreaElement.prototype, {
     get value(){
         return this.innerText;
     },
+    set value(value){
+        this.innerText=value;
+    },
     set rows(value){
         this.setAttribute('rows', value);
     }

--- a/src/html/textarea.js
+++ b/src/html/textarea.js
@@ -17,6 +17,9 @@ __extend__(HTMLTextAreaElement.prototype, {
     get rows(){
         return this.getAttribute('rows');
     },
+    get value(){
+        return this.innerText;
+    },
     set rows(value){
         this.setAttribute('rows', value);
     }

--- a/test/unit/elementmembers.js
+++ b/test/unit/elementmembers.js
@@ -7,7 +7,7 @@ test("textarea content", function() {
   var textarea = document.createElement('textarea');
   var text     = document.createTextNode('text-area-content');
   textarea.appendChild(text);
-alert(textarea.value);
+
   try { ok(textarea.value == 'text-area-content',
         "textarea.value returns the correct content, as per http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-24874179");
   }catch(e){print(e);}

--- a/test/unit/elementmembers.js
+++ b/test/unit/elementmembers.js
@@ -3,6 +3,20 @@ module("elementmembers");
 // We ought to have test coverage for all members of all DOM objects, but
 // until then, add test cases here for members as they are created
 
+test("textarea content", function() {
+  var textarea = document.createElement('textarea');
+  var text     = document.createTextNode('text-area-content');
+  textarea.appendChild(text);
+alert(textarea.value);
+  try { ok(textarea.value == 'text-area-content',
+        "textarea.value returns the correct content, as per http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-24874179");
+  }catch(e){print(e);}
+  
+  try { ok(textarea.innerText == 'text-area-content',
+        "textarea.innerText returns the correct content");
+  }catch(e){print(e);}
+});
+
 test("attributes common to all HTML elements", function() {
     expect(4);
 

--- a/test/unit/elementmembers.js
+++ b/test/unit/elementmembers.js
@@ -4,6 +4,8 @@ module("elementmembers");
 // until then, add test cases here for members as they are created
 
 test("textarea content", function() {
+  expect(2);
+  
   var textarea = document.createElement('textarea');
   var text     = document.createTextNode('text-area-content');
   textarea.appendChild(text);

--- a/test/unit/elementmembers.js
+++ b/test/unit/elementmembers.js
@@ -3,7 +3,23 @@ module("elementmembers");
 // We ought to have test coverage for all members of all DOM objects, but
 // until then, add test cases here for members as they are created
 
-test("textarea content", function() {
+test("setting textarea content", function() {
+  expect(2);
+  
+  var textarea = document.createElement('textarea');
+
+  try { textarea.value = 'textarea-value';
+        ok(textarea.value == 'textarea-value',
+        "textarea.value= sets the value correctly");
+  }catch(e){print(e);}
+  
+  try { textarea.innerText = 'textarea-innerText';
+        ok(textarea.innerText == 'textarea-innerText',
+        "textarea.innerText= sets the value correctly");
+  }catch(e){print(e);}
+});
+
+test("getting textarea content", function() {
   expect(2);
   
   var textarea = document.createElement('textarea');


### PR DESCRIPTION
Hey Steven,

We noticed that implementing the textarea 'value' getter caused spidermonkey errors should one try to set the 'value'.  The most recent commit (25f0c297df37eb911e3dfa0b937f7ba686a162e0) to our fork fixes this.

Cheers, Chris
